### PR TITLE
feat: add support for theme

### DIFF
--- a/src/components/CodeEditor/Editor.tsx
+++ b/src/components/CodeEditor/Editor.tsx
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from 'react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { liftOff } from './token-config';
-import monokai from './theme.json';
+import cobalt from './theme.json';
 
 interface EditorProps {
 	value: string;
@@ -50,7 +50,7 @@ class Editor extends Component<EditorProps> {
 	initEditor = async () => {
 		const node = this.editorRef.current;
 		const { language, value } = this.props;
-		const colors = monokai.colors;
+		const colors = cobalt.colors;
 		const newColors = colors;
 		Object.keys(colors).forEach(c => {
 			if (newColors[c]) return c;
@@ -60,7 +60,6 @@ class Editor extends Component<EditorProps> {
 			return c;
 		});
 		if (node) {
-			await liftOff(monaco);
 			monaco.editor.create(node, {
 				value,
 				language,
@@ -68,11 +67,12 @@ class Editor extends Component<EditorProps> {
 			monaco.editor.defineTheme('myCustomTheme', {
 				base: 'vs-dark',
 				inherit: true,
-				rules: tokenizeStringRules(monokai.tokenColors),
+				rules: tokenizeStringRules(cobalt.tokenColors),
 				colors,
 			});
 
 			monaco.editor.setTheme('myCustomTheme');
+			await liftOff(monaco);
 		}
 	};
 

--- a/src/components/CodeEditor/Editor.tsx
+++ b/src/components/CodeEditor/Editor.tsx
@@ -1,12 +1,39 @@
 import React, { Component, createRef } from 'react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { liftOff } from './token-config';
+import monokai from './theme.json';
 
 interface EditorProps {
 	value: string;
 	language: string;
 	theme: string;
 }
+
+const tokenizeStringRules = tokenColors =>
+	tokenColors
+		.filter(token => token.scope && token.settings)
+		.reduce((acc, token) => {
+			const tokenSettings = {
+				foreground: token.settings.foreground,
+				background: token.settings.background,
+				fontStyle: token.settings.fontStyle,
+			};
+			if (typeof token.scope === 'string') {
+				const allScopes = token.scope.split(',');
+
+				const allRules = allScopes.map(item => ({
+					token: item,
+					...tokenSettings,
+				}));
+
+				return [...acc, ...allRules];
+			}
+			const allRules = token.scope.map(item => ({
+				token: item,
+				...tokenSettings,
+			}));
+			return [...acc, ...allRules];
+		}, []);
 
 class Editor extends Component<EditorProps> {
 	private editorRef = createRef<HTMLDivElement>();
@@ -22,12 +49,33 @@ class Editor extends Component<EditorProps> {
 
 	initEditor = async () => {
 		const node = this.editorRef.current;
-		const { language, theme, value } = this.props;
+		const { language, value } = this.props;
+		const colors = monokai.colors;
+		const newColors = colors;
+		Object.keys(colors).forEach(c => {
+			if (newColors[c]) return c;
+
+			delete newColors[c];
+
+			return c;
+		});
 		if (node) {
 			await liftOff(monaco);
-			monaco.editor.create(node, { value, theme, language });
+			monaco.editor.create(node, {
+				value,
+				language,
+			});
+			monaco.editor.defineTheme('myCustomTheme', {
+				base: 'vs-dark',
+				inherit: true,
+				rules: tokenizeStringRules(monokai.tokenColors),
+				colors,
+			});
+
+			monaco.editor.setTheme('myCustomTheme');
 		}
 	};
+
 	render() {
 		return <div style={{ height: '70vh' }} ref={this.editorRef} />;
 	}

--- a/src/components/CodeEditor/theme.json
+++ b/src/components/CodeEditor/theme.json
@@ -1,0 +1,807 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Cobalt",
+	"type": "dark",
+	"colors": {
+		"activityBar.background": "#122738",
+		"activityBar.border": "#0d3a58",
+		"activityBar.dropBackground": "#0d3a58",
+		"activityBar.foreground": "#ffffff",
+		"activityBarBadge.background": "#ffc600",
+		"activityBarBadge.foreground": "#000",
+		"badge.background": "#ffc600",
+		"badge.foreground": "#000",
+		"button.background": "#0088ff",
+		"button.foreground": "#ffffff",
+		"button.hoverBackground": "#ff9d00",
+		"contrastActiveBorder": null,
+		"contrastBorder": "#ffffff00",
+		"debugExceptionWidget.background": "#193549",
+		"debugExceptionWidget.border": "#aaa",
+		"debugToolBar.background": "#193549",
+		"descriptionForeground": "#aaa",
+		"diffEditor.insertedTextBackground": "#3ad90033",
+		"diffEditor.insertedTextBorder": "#3ad90055",
+		"diffEditor.removedTextBackground": "#ee3a4333",
+		"diffEditor.removedTextBorder": "#ee3a4355",
+		"dropdown.background": "#193549",
+		"dropdown.border": "#15232d",
+		"dropdown.foreground": "#ffffff",
+		"editor.background": "#193549",
+		"editor.foreground": "#ffffff",
+		"editor.findMatchBackground": "#FF720066",
+		"editor.findMatchHighlightBackground": "#CAD40F66",
+		"editor.findRangeHighlightBackground": "#243E51",
+		"editor.hoverHighlightBackground": "#ffc60033",
+		"editor.inactiveSelectionBackground": "#003b8b",
+		"editor.lineHighlightBackground": "#1F4662",
+		"editor.lineHighlightBorder": "#234E6D",
+		"editor.rangeHighlightBackground": "#1F4662",
+		"editor.selectionBackground": "#0050A4",
+		"editor.selectionHighlightBackground": "#0050A480",
+		"editor.wordHighlightStrongBackground": "#ffffff21",
+		"editor.wordHighlightBackground": "#ffffff21",
+		"editorBracketMatch.background": "#0d3a58",
+		"editorBracketMatch.border": "#ffc60080",
+		"editorCodeLens.foreground": "#aaaaaa",
+		"editorCursor.foreground": "#ffc600",
+		"editorError.border": "#0d3a58",
+		"editorError.foreground": "#A22929",
+		"editorGutter.background": "#12273866",
+		"editorGutter.addedBackground": "#3C9F4A",
+		"editorGutter.deletedBackground": "#A22929",
+		"editorGutter.modifiedBackground": "#26506D",
+		"editorGroup.background": "#A22929",
+		"editorGroup.border": "#122738",
+		"editorGroup.dropBackground": "#12273899",
+		"editorGroupHeader.noTabsBackground": "#193549",
+		"editorGroupHeader.tabsBackground": "#193549",
+		"editorGroupHeader.tabsBorder": "#15232d",
+		"editorHoverWidget.background": "#15232d",
+		"editorHoverWidget.border": "#0d3a58",
+		"editorIndentGuide.background": "#3B5364",
+		"editorLineNumber.foreground": "#aaaaaa",
+		"editorLink.activeForeground": "#aaaaaa",
+		"editorMarkerNavigation.background": "#3B536433",
+		"editorMarkerNavigationError.background": "#A22929",
+		"editorMarkerNavigationWarning.background": "#ffc600",
+		"editorOverviewRuler.border": "#0d3a58",
+		"editorOverviewRuler.commonContentForeground": "#ffc60055",
+		"editorOverviewRuler.currentContentForeground": "#ee3a4355",
+		"editorOverviewRuler.incomingContentForeground": "#3ad90055",
+		"editorRuler.foreground": "#1F4662",
+		"editorSuggestWidget.background": "#15232d",
+		"editorSuggestWidget.border": "#15232d",
+		"editorSuggestWidget.foreground": "#aaaaaa",
+		"editorSuggestWidget.highlightForeground": "#ffc600",
+		"editorWarning.border": "#ffffff00",
+		"editorWarning.foreground": "#ffc600",
+		"editorWhitespace.foreground": "#ffffff1a",
+		"editorWidget.background": "#15232d",
+		"editorWidget.border": "#0d3a58",
+		"extensionButton.prominentBackground": "#0088ff",
+		"extensionButton.prominentForeground": "#ffffff",
+		"extensionButton.prominentHoverBackground": "#ff9d00",
+		"focusBorder": "#0d3a58",
+		"input.background": "#193549",
+		"input.border": "#0d3a58",
+		"input.foreground": "#ffc600",
+		"input.placeholderForeground": "#aaaaaa",
+		"inputOption.activeBorder": "#8dffff",
+		"inputValidation.errorBackground": "#193549",
+		"inputValidation.errorBorder": "#ffc600",
+		"inputValidation.infoBackground": "#193549",
+		"inputValidation.infoBorder": "#0D3A58",
+		"inputValidation.warningBackground": "#193549",
+		"list.activeSelectionBackground": "#193549",
+		"list.activeSelectionForeground": "#aaaaaa",
+		"list.dropBackground": "#0d3a58",
+		"list.focusBackground": "#0d3a58",
+		"list.focusForeground": "#aaa",
+		"list.highlightForeground": "#ffc600",
+		"list.hoverBackground": "#193549",
+		"list.hoverForeground": "#aaaaaa",
+		"list.inactiveSelectionBackground": "#0d3a58",
+		"menu.background": "#122738",
+		"merge.border": "#ffffff00",
+		"merge.commonContentBackground": "#c97d0c",
+		"merge.commonHeaderBackground": "#c97d0c",
+		"merge.currentContentBackground": "#2F7366",
+		"merge.currentHeaderBackground": "#2F7366",
+		"merge.incomingContentBackground": "#185294",
+		"merge.incomingHeaderBackground": "#185294",
+		"notificationCenter.border": "#ffc600",
+		"notificationCenterHeader.foreground": "#aaaaaa",
+		"notificationCenterHeader.background": "#122738",
+		"notificationToast.border": "#ffc600",
+		"notifications.foreground": "#aaaaaa",
+		"notifications.background": "#122738",
+		"notifications.border": "#ffc600",
+		"notificationLink.foreground": "#ffc600",
+		"notification.background": "#ffc600",
+		"notification.buttonBackground": "#0088ff",
+		"notification.buttonForeground": "#ffffff",
+		"notification.buttonHoverBackground": "#ff9d00",
+		"notification.errorBackground": "#A22929",
+		"notification.errorForeground": "#ffffff",
+		"notification.foreground": "#000",
+		"notification.infoBackground": "#0088ff",
+		"notification.infoForeground": "#ffffff",
+		"notification.warningBackground": "#ff9d00",
+		"notification.warningForeground": "#000",
+		"panel.background": "#122738",
+		"panel.border": "#ffc600",
+		"panelTitle.activeBorder": "#ffc600",
+		"panelTitle.activeForeground": "#ffc600",
+		"panelTitle.inactiveForeground": "#aaaaaa",
+		"peekView.border": "#ffc600",
+		"peekViewEditor.background": "#193549",
+		"peekViewEditor.matchHighlightBackground": "#19354900",
+		"peekViewEditorGutter.background": "#122738",
+		"peekViewResult.background": "#15232d",
+		"peekViewResult.fileForeground": "#aaaaaa",
+		"peekViewResult.lineForeground": "#ffffff",
+		"peekViewResult.matchHighlightBackground": "#0d3a58",
+		"peekViewResult.selectionBackground": "#0d3a58",
+		"peekViewResult.selectionForeground": "#ffffff",
+		"peekViewTitle.background": "#15232d",
+		"peekViewTitleDescription.foreground": "#aaaaaa",
+		"peekViewTitleLabel.foreground": "#ffc600",
+		"pickerGroup.border": "#0d3a58",
+		"pickerGroup.foreground": "#aaaaaa",
+		"progressBar.background": "#ffc600",
+		"scrollbar.shadow": "#00000000",
+		"scrollbarSlider.activeBackground": "#355166cc",
+		"scrollbarSlider.background": "#1F466280",
+		"scrollbarSlider.hoverBackground": "#406179cc",
+		"selection.background": "#027dff",
+		"sideBar.background": "#15232d",
+		"sideBar.border": "#0d3a58",
+		"sideBar.foreground": "#aaaaaa",
+		"sideBarSectionHeader.background": "#193549",
+		"sideBarSectionHeader.foreground": "#aaaaaa",
+		"sideBarTitle.foreground": "#aaaaaa",
+		"statusBar.background": "#15232d",
+		"statusBar.border": "#0d3a58",
+		"statusBar.debuggingBackground": "#15232d",
+		"statusBar.debuggingBorder": "#ffc600",
+		"statusBar.debuggingForeground": "#ffc600",
+		"statusBar.foreground": "#aaaaaa",
+		"statusBar.noFolderBackground": "#15232d",
+		"statusBar.noFolderBorder": "#0d3a58",
+		"statusBar.noFolderForeground": "#aaa",
+		"statusBarItem.activeBackground": "#0088ff",
+		"statusBarItem.hoverBackground": "#0d3a58",
+		"statusBarItem.prominentBackground": "#15232d",
+		"statusBarItem.prominentHoverBackground": "#0d3a58",
+		"tab.activeBackground": "#122738",
+		"tab.activeForeground": "#ffffff",
+		"tab.border": "#15232D",
+		"tab.activeBorder": "#ffc600",
+		"tab.inactiveBackground": "#193549",
+		"tab.inactiveForeground": "#aaaaaa",
+		"tab.unfocusedActiveForeground": "#aaaaaa",
+		"tab.unfocusedInactiveForeground": "#aaaaaa",
+		"terminal.ansiBlack": "#000000",
+		"terminal.ansiRed": "#ff628c",
+		"terminal.ansiGreen": "#3ad900",
+		"terminal.ansiYellow": "#ffc600",
+		"terminal.ansiBlue": "#0088ff",
+		"terminal.ansiMagenta": "#fb94ff",
+		"terminal.ansiCyan": "#80fcff",
+		"terminal.ansiWhite": "#ffffff",
+		"terminal.ansiBrightBlack": "#0050A4",
+		"terminal.ansiBrightRed": "#ff628c",
+		"terminal.ansiBrightGreen": "#3ad900",
+		"terminal.ansiBrightYellow": "#ffc600",
+		"terminal.ansiBrightBlue": "#0088ff",
+		"terminal.ansiBrightMagenta": "#fb94ff",
+		"terminal.ansiBrightCyan": "#80fcff",
+		"terminal.ansiBrightWhite": "#193549",
+		"terminal.background": "#122738",
+		"terminal.foreground": "#ffffff",
+		"terminalCursor.background": "#ffc600",
+		"terminalCursor.foreground": "#ffc600",
+		"gitDecoration.modifiedResourceForeground": "#ffc600",
+		"gitDecoration.deletedResourceForeground": "#ff628c",
+		"gitDecoration.untrackedResourceForeground": "#3ad900",
+		"gitDecoration.ignoredResourceForeground": "#808080",
+		"gitDecoration.conflictingResourceForeground": "#FF7200",
+		"textBlockQuote.background": "#193549",
+		"textBlockQuote.border": "#0088ff",
+		"textCodeBlock.background": "#193549",
+		"textLink.activeForeground": "#0088ff",
+		"textLink.foreground": "#0088ff",
+		"textPreformat.foreground": "#ffc600",
+		"textSeparator.foreground": "#0d3a58",
+		"titleBar.activeBackground": "#15232D",
+		"titleBar.activeForeground": "#ffffff",
+		"titleBar.inactiveBackground": "#193549",
+		"titleBar.inactiveForeground": "#ffffff33",
+		"walkThrough.embeddedEditorBackground": "#0d3a58",
+		"welcomePage.buttonBackground": "#193549",
+		"welcomePage.buttonHoverBackground": "#0d3a58",
+		"widget.shadow": "#00000026"
+	},
+	"tokenColors": [
+		{
+			"name": "Comment",
+			"scope": ["comment", "punctuation.definition.comment"],
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#0088ff"
+			}
+		},
+		{
+			"name": "Constant",
+			"scope": "constant",
+			"settings": {
+				"foreground": "#ff628c"
+			}
+		},
+		{
+			"name": "Entity",
+			"scope": "entity",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "Invalid",
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#f44542"
+			}
+		},
+		{
+			"name": "Storage Type Function",
+			"scope": "storage.type.function",
+			"settings": {
+				"foreground": "#ff9d00"
+			}
+		},
+		{
+			"name": "Keyword",
+			"scope": "keyword, storage.type.class",
+			"settings": {
+				"foreground": "#ff9d00"
+			}
+		},
+		{
+			"name": "Meta",
+			"scope": "meta",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "Meta JSX",
+			"scope": [
+				"meta.jsx.children",
+				"meta.jsx.children.js",
+				"meta.jsx.children.tsx"
+			],
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "Meta Brace",
+			"scope": "meta.brace",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "Punctuation",
+			"scope": "punctuation",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "Punctuation Parameters",
+			"scope": "punctuation.definition.parameters",
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "Punctuation Template Expression",
+			"scope": "punctuation.definition.template-expression",
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "Storage",
+			"scope": "storage",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "Storage Type Arrow Function",
+			"scope": "storage.type.function.arrow",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "String",
+			"scope": ["string", "punctuation.definition.string"],
+			"settings": {
+				"foreground": "#a5ff90"
+			}
+		},
+		{
+			"name": "String Template",
+			"scope": [
+				"string.template",
+				"punctuation.definition.string.template"
+			],
+			"settings": {
+				"foreground": "#3ad900"
+			}
+		},
+		{
+			"name": "Support",
+			"scope": "support",
+			"settings": {
+				"foreground": "#80ffbb"
+			}
+		},
+		{
+			"name": "Support Function",
+			"scope": "support.function",
+			"settings": {
+				"foreground": "#ff9d00"
+			}
+		},
+		{
+			"name": "Support Variable Property DOM",
+			"scope": "support.variable.property.dom",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "Variable",
+			"scope": "variable",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[CSS] - Entity",
+			"scope": ["source.css entity", "source.stylus entity"],
+			"settings": {
+				"foreground": "#3ad900"
+			}
+		},
+		{
+			"name": "[CSS] - ID Selector",
+			"scope": "entity.other.attribute-name.id.css",
+			"settings": {
+				"foreground": "#FFB454"
+			}
+		},
+		{
+			"name": "[CSS] - Element Selector",
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#9EFFFF"
+			}
+		},
+		{
+			"name": "[CSS] - Support",
+			"scope": ["source.css support", "source.stylus support"],
+			"settings": {
+				"foreground": "#a5ff90"
+			}
+		},
+		{
+			"name": "[CSS] - Constant",
+			"scope": [
+				"source.css constant",
+				"source.css support.constant",
+				"source.stylus constant",
+				"source.stylus support.constant"
+			],
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "[CSS] - String",
+			"scope": [
+				"source.css string",
+				"source.css punctuation.definition.string",
+				"source.stylus string",
+				"source.stylus punctuation.definition.string"
+			],
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "[CSS] - Variable",
+			"scope": ["source.css variable", "source.stylus variable"],
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[HTML] - Entity Name",
+			"scope": "text.html.basic entity.name",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[HTML] - ID value",
+			"scope": "meta.toc-list.id.html",
+			"settings": {
+				"foreground": "#A5FF90"
+			}
+		},
+		{
+			"name": "[HTML] - Entity Other",
+			"scope": "text.html.basic entity.other",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[HTML] - Script Tag",
+			"scope": "meta.tag.metadata.script.html entity.name.tag.html",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
+			"scope": "punctuation.definition.string.begin, punctuation.definition.string.end",
+			"settings": {
+				"foreground": "#92fc79"
+			}
+		},
+		{
+			"name": "[INI] - Entity",
+			"scope": "source.ini entity",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[INI] - Keyword",
+			"scope": "source.ini keyword",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[INI] - Punctuation Definition",
+			"scope": "source.ini punctuation.definition",
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "[INI] - Punctuation Separator",
+			"scope": "source.ini punctuation.separator",
+			"settings": {
+				"foreground": "#ff9d00"
+			}
+		},
+		{
+			"name": "[JAVASCRIPT] - Storage Type Function",
+			"scope": "source.js storage.type.function",
+			"settings": {
+				"foreground": "#fb94ff"
+			}
+		},
+		{
+			"name": "[JAVASCRIPT] - Variable Language",
+			"scope": "variable.language, entity.name.type.class.js",
+			"settings": {
+				"foreground": "#fb94ff"
+			}
+		},
+		{
+			"name": "[JAVASCRIPT] - Inherited Component",
+			"scope": "entity.other.inherited-class.js",
+			"settings": {
+				"foreground": "#cccccc"
+			}
+		},
+		{
+			"name": "[PYTHON] - Self Argument",
+			"scope": "variable.parameter.function.language.special.self.python",
+			"settings": {
+				"foreground": "#fb94ff"
+			}
+		},
+		{
+			"name": "[JSON] - Support",
+			"scope": "source.json support",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[JSON] - String",
+			"scope": [
+				"source.json string",
+				"source.json punctuation.definition.string"
+			],
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Heading Punctuation",
+			"scope": "punctuation.definition.heading.markdown",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Heading Name Section",
+			"scope": [
+				"entity.name.section.markdown",
+				"markup.heading.setext.1.markdown",
+				"markup.heading.setext.2.markdown"
+			],
+			"settings": {
+				"foreground": "#ffc600",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Paragraph",
+			"scope": "meta.paragraph.markdown",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Quote Punctuation",
+			"scope": "beginning.punctuation.definition.quote.markdown",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Quote Paragraph",
+			"scope": "markup.quote.markdown meta.paragraph.markdown",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Separator",
+			"scope": "meta.separator.markdown",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Emphasis Bold",
+			"scope": "markup.bold.markdown",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Emphasis Italic",
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Lists",
+			"scope": "beginning.punctuation.definition.list.markdown",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Link Title",
+			"scope": "string.other.link.title.markdown",
+			"settings": {
+				"foreground": "#a5ff90"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Link/Image Title",
+			"scope": [
+				"string.other.link.title.markdown",
+				"string.other.link.description.markdown",
+				"string.other.link.description.title.markdown"
+			],
+			"settings": {
+				"foreground": "#a5ff90"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Link Address",
+			"scope": [
+				"markup.underline.link.markdown",
+				"markup.underline.link.image.markdown"
+			],
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Inline Code",
+			"scope": [
+				"fenced_code.block.language",
+				"markup.inline.raw.markdown"
+			],
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[MARKDOWN] - Code Block",
+			"scope": [
+				"fenced_code.block.language",
+				"markup.inline.raw.markdown"
+			],
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[PUG] - Entity Name",
+			"scope": "text.jade entity.name",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[PUG] - Entity Attribute Name",
+			"scope": "text.jade entity.other.attribute-name.tag",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "[PUG] - String Interpolated",
+			"scope": "text.jade string.interpolated",
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Entity Name Type",
+			"scope": "source.ts entity.name.type",
+			"settings": {
+				"foreground": "#80ffbb"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Keyword",
+			"scope": "source.ts keyword",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Punctuation Parameters",
+			"scope": "source.ts punctuation.definition.parameters",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Punctuation Arrow Parameters",
+			"scope": "meta.arrow.ts punctuation.definition.parameters",
+			"settings": {
+				"foreground": "#ffee80"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Storage",
+			"scope": "source.ts storage",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Variable Language",
+			"scope": "variable.language, entity.name.type.class.ts, entity.name.type.class.tsx",
+			"settings": {
+				"foreground": "#fb94ff"
+			}
+		},
+		{
+			"name": "[TYPESCRIPT] - Inherited Component",
+			"scope": "entity.other.inherited-class.ts, entity.other.inherited-class.tsx",
+			"settings": {
+				"foreground": "#cccccc"
+			}
+		},
+		{
+			"name": "[PHP] - Entity",
+			"scope": "source.php entity",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[PHP] - Variables",
+			"scope": "variable.other.php",
+			"settings": {
+				"foreground": "#ffc600"
+			}
+		},
+		{
+			"name": "[C#] - Annotations",
+			"scope": "storage.type.cs",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[C#] - Properties",
+			"scope": "entity.name.variable.property.cs",
+			"settings": {
+				"foreground": "#9effff"
+			}
+		},
+		{
+			"name": "[C#] - Storage modifiers",
+			"scope": "storage.modifier.cs",
+			"settings": {
+				"foreground": "#80ffbb"
+			}
+		},
+		{
+			"name": "Italicsify for Operator Mono",
+			"scope": [
+				"modifier",
+				"this",
+				"comment",
+				"storage.modifier.js",
+				"storage.modifier.ts",
+				"storage.modifier.tsx",
+				"entity.other.attribute-name.js",
+				"entity.other.attribute-name.ts",
+				"entity.other.attribute-name.tsx",
+				"entity.other.attribute-name.html"
+			],
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "[CSHARP] - Modifiers and keyword types",
+			"scope": "storage.modifier.cs, keyword.type.cs",
+			"settings": {
+				"foreground": "#fb94ff"
+			}
+		},
+		{
+			"name": "[CSHARP] - Storage types",
+			"scope": "storage.type.cs",
+			"settings": {
+				"foreground": "#80ffbb"
+			}
+		},
+		{
+			"name": "[CSHARP] - Namespaces, parameters, field variables, properties",
+			"scope": "entity.name.type.namespace.cs, entity.name.variable.parameter.cs, entity.name.variable.field.cs, entity.name.variable.property.cs",
+			"settings": {
+				"foreground": "#e1efff"
+			}
+		}
+	]
+}


### PR DESCRIPTION
@lakhansamani It looks like the grammars are not loaded correctly so the color for the tokens doesn't match. You can easily replicate this by pressing `F1` and searching for `Inspect Tokens` you will note that console is marked as Other and thus styles are not loaded correctly. 

This PR add supports for Cobalt2 we can change this to a util function ( more cleaner and simpler ) in next iteration but first we need to fix the grammar.